### PR TITLE
Sidebar: one selection wash, no second fade

### DIFF
--- a/Fila/Interface/Sidebar/SidebarViewController.swift
+++ b/Fila/Interface/Sidebar/SidebarViewController.swift
@@ -257,6 +257,17 @@ final class SidebarViewController: UIViewController {
     private func buildDataSource() {
         let row = UICollectionView.CellRegistration<IconRowCell, Item> { [weak self] cell, _, item in
             self?.configure(cell, for: item)
+            // One look for a pressed row and a selected one: the light tint,
+            // not the system's solid fill for a selection. The grouped-cell
+            // base keeps the card's corners on iOS 18 as on 26.
+            cell.configurationUpdateHandler = { cell, state in
+                var background = UIBackgroundConfiguration.listGroupedCell().updated(for: state)
+                if state.isSelected || state.isHighlighted {
+                    background.backgroundColorTransformer = nil
+                    background.backgroundColor = UIColor.tintColor.withAlphaComponent(FilaUI.selectionTintAlpha)
+                }
+                cell.backgroundConfiguration = background
+            }
         }
         let header = UICollectionView.CellRegistration<UICollectionViewListCell, Section> { cell, _, section in
             var content = UIListContentConfiguration.sidebarHeader()
@@ -562,7 +573,9 @@ extension SidebarViewController: UICollectionViewDelegate {
         case let .recent(path):
             openRecent(path)
         case let .catalog(id), let .connection(id):
-            collectionView.deselectItem(at: indexPath, animated: true)
+            // Stays selected, like a place: the row is where the content
+            // column now is. A deselect here was a second fade right after
+            // the press — one blink for the tap, one for letting go.
             guard let screen = SidebarLocation.screen(for: .root(of: id)) else { return }
             shell?.replace(screen)
         }

--- a/Packages/FilaKit/Sources/FilaBackendUI/FilaUI.swift
+++ b/Packages/FilaKit/Sources/FilaBackendUI/FilaUI.swift
@@ -19,6 +19,10 @@ public enum FilaUI {
 
     public static let minimumTapTarget: CGFloat = 44
 
+    /// The accent, this faint, is a pressed or selected sidebar row: the
+    /// same wash for both, never the system's solid fill.
+    public static let selectionTintAlpha: CGFloat = 0.15
+
     /// Every form sheet the app presents is this one size — settings, a
     /// server's setup, the compress form, a picker — so sheets do not
     /// step between sizes as one replaces another. Compact widths ignore


### PR DESCRIPTION
## Summary

- A pressed sidebar row and a selected one are the same light accent tint (`FilaUI.selectionTintAlpha`), replacing the solid system fill place rows showed once selected.
- Server and catalogue rows stay selected like places instead of fading right after the tap, which read as two blinks.

## Verification

- `make check`; simulator Debug build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgW42UFhpEmb8Ty3saJJ5h
